### PR TITLE
Fix device_ports.xcd not saved when default.prf is unchanged

### DIFF
--- a/src/Dialogs/Device/ManageI2CPitotDialog.cpp
+++ b/src/Dialogs/Device/ManageI2CPitotDialog.cpp
@@ -92,7 +92,7 @@ ManageI2CPitotWidget::Calibrate() noexcept
   config.sensor_offset = GetValueFloat(PITOT)
     + device.GetConfig().sensor_offset - GetValueFloat(STATIC);
 
-  Profile::SetDeviceConfig(Profile::map, index, config);
+  Profile::SetDeviceConfig(Profile::device_ports, index, config);
   Profile::Save();
 
   device.SetConfig(config);

--- a/src/Profile/Profile.cpp
+++ b/src/Profile/Profile.cpp
@@ -126,7 +126,7 @@ Profile::LoadFile(Path path) noexcept
 void
 Profile::Save(ProfileMap &_map) noexcept
 {
-  if (!map.IsModified())
+  if (!_map.IsModified())
     return;
 
   Path path = (&_map == &device_ports) ? portSettingFile : startProfileFile;


### PR DESCRIPTION
## Problem

`Profile::Save(ProfileMap &)` returned early when **`map` (default.prf)** was not modified. The device list calls `Profile::Save(Profile::device_ports)` after editing NMEA devices; if nothing else had dirtied the main profile, **`device_ports.xcd` was never written**, so COM/serial/TCP/driver settings appeared to save in-session but were lost on restart.

## Changes

- **`Profile::Save(ProfileMap &)`**: gate on `_map.IsModified()` instead of `map.IsModified()`.
- **`ManageI2CPitotDialog`**: write pitot calibration via `SetDeviceConfig(Profile::device_ports, …)` so it matches `Profile::UseDevices()`, which loads system/device settings only from `device_ports`.

## Related issues

- Related to #21 (peripherals not retained — this targets the **device connection** side; **polar** persistence may still need a separate check).
- Related to #16 (driver not restored — same underlying split between `default.prf` and `device_ports.xcd`).

Please verify on hardware after merge.